### PR TITLE
fix: import reformatted [#32513]

### DIFF
--- a/common/djangoapps/util/file.py
+++ b/common/djangoapps/util/file.py
@@ -8,7 +8,8 @@ from datetime import datetime
 
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
-from django.core.files.storage import DefaultStorage, get_valid_filename
+from django.core.files.storage import DefaultStorage
+from django.utils.text import get_valid_filename
 from django.utils.translation import gettext as _
 from django.utils.translation import ngettext
 from pytz import UTC


### PR DESCRIPTION
Fixes

```
from django.core.files.storage import DefaultStorage, get_valid_filename
ImportError: cannot import name 'get_valid_filename' from 'django.core.files.storage'
```


- The DEFAULT_FILE_STORAGE and STATICFILES_STORAGE settings will be removed.
- The django.core.files.storage.get_storage_class() function will be removed.

For Django 4.2 these functionalities doesn't require any change in edx-platform.